### PR TITLE
Wait for state change in noble before firing the scan start.

### DIFF
--- a/lib/drone.js
+++ b/lib/drone.js
@@ -106,8 +106,17 @@ Drone.prototype.connect = function (callback) {
     }
 
   }.bind(this));
-  this.logger('Scanning');
-  this.ble.startScanning();
+
+  this.ble.on('stateChange', function (state) {
+    if (state == 'poweredOn') {
+      this.logger('Scanning');
+      this.ble.startScanning();
+    } else {
+      callback(new Error('Error with Bluetooth Adapter, please retry'));
+      this.ble.stopScanning();
+    }
+  }.bind(this));
+
 };
 
 /**


### PR DESCRIPTION
This uses nobles 'stateChange' to wait for the notification that bluetooth is settled before attempting to scan. This solves an issue of running the code via crouton on a chromebook (which is yes an insane operating environment).

