### PR TITLE
Fix bug in RollingSpider.createClient

### DIFF
--- a/lib/drone.js
+++ b/lib/drone.js
@@ -75,7 +75,6 @@ util.inherits(Drone, EventEmitter);
 
 // create client helper function to match ar-drone
 Drone.createClient = function (options) {
-  this.logger('RollingSpider#createClient');
   return new Drone(options);
 };
 

--- a/lib/drone.js
+++ b/lib/drone.js
@@ -162,9 +162,9 @@ Drone.prototype.connectPeripheral = function (peripheral, onConnected) {
   this.peripheral = peripheral;
   this.peripheral.connect(onConnected);
   this.peripheral.on('disconnect', function () {
-    this.onDisconnect()
+    this.onDisconnect();
   }.bind(this));
-}
+};
 
 /**
  * Sets up the connection to the drone and enumerate all of the services and characteristics.
@@ -199,7 +199,7 @@ Drone.prototype.setup = function (callback) {
 Drone.prototype.handshake = function (callback) {
   this.logger('RollingSpider#handshake');
   ['fb0f', 'fb0e', 'fb1b', 'fb1c', 'fd22', 'fd23', 'fd24', 'fd52', 'fd53', 'fd54'].forEach(function (key) {
-    var characteristic = this.getCharacteristic(key)
+    var characteristic = this.getCharacteristic(key);
     characteristic.notify(true);
   }.bind(this));
 
@@ -308,8 +308,7 @@ Drone.prototype.onDisconnect = function () {
   //
     this.emit('disconnected');
   }
-
-}
+};
 
 /**
  * 'Disconnects' from the drone

--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
     "noble": "^0.3.14"
   },
   "devDependencies": {
-    "keypress": "^0.2.1"
+    "grunt-contrib-jshint": "^0.11.2",
+    "grunt-mocha-test": "^0.12.7",
+    "keypress": "^0.2.1",
+    "mocha": "^2.2.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I was unable to call `RollingSpider.createClient` because `this.logger` doesn't exists in this context.