### PR TITLE
Unlock Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An implementation of the networking protocols (Bluetooth LE) used by the
 
 Prerequisites:
 
- * See [noble prerequisites](https://github.com/sandeepmistry/noble#prerequisites) for you platform
+ * See [noble prerequisites](https://github.com/sandeepmistry/noble#prerequisites) for your platform
 
 To install:
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 An implementation of the networking protocols (Bluetooth LE) used by the
 [Parrot MiniDrone - Rolling Spider](http://www.parrot.com/usa/products/rolling-spider/). This offers an off-the-shelf $99 USD drone that can be controlled by JS -- yay!
 
+Prerequisites:
+
+ * See [noble prerequisites](https://github.com/sandeepmistry/noble#prerequisites) for you platform
+
 To install:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "debug": "^2.1.1",
     "lodash": "3.9.3",
-    "noble": "^1.0.0"
+    "noble": "^1.1.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "^0.11.2",
@@ -62,6 +62,7 @@
   },
   "os": [
     "darwin",
-    "linux"
+    "linux",
+    "win32"
   ]
 }


### PR DESCRIPTION
Upgrade noble dependency to v1.1 which now supports Windows via WinUSB (addresses #27).

To run on Windows, you need to use [Zadig tool](http://zadig.akeo.ie/) to enable the WinUSB driver for a [compatible USB Bluetooth 4.0](https://github.com/sandeepmistry/node-bluetooth-hci-socket#compatible-bluetooth-40-usb-adapters). noble then uses [node-bluetooth-hci-socket](https://github.com/sandeepmistry/node-bluetooth-hci-socket) along with [node-usb](https://github.com/nonolith/node-usb) to talk directly to the USB adapter. This bypasses the built-in Bluetooth stack in Windows, so the adapter can only be used with noble or bleno. 

See [noble prerequisites for Windows](https://github.com/sandeepmistry/noble#windows) and [node-bluetooth-hci-socket prerequisites for Windows](https://github.com/sandeepmistry/node-bluetooth-hci-socket#windows) for more info.
