### PR TITLE
Add support for Mambo mini drone.

### DIFF
--- a/lib/drone.js
+++ b/lib/drone.js
@@ -91,7 +91,7 @@ Drone.isDronePeripheral = function(peripheral) {
   var manufacturer = peripheral.advertisement.manufacturerData;
 
   var localNameMatch = localName
-    && (localName.indexOf('RS_') === 0 || localName.indexOf('Mars_') === 0 || localName.indexOf('Travis_') === 0  || localName.indexOf('Maclan_')=== 0);
+    && (localName.indexOf('RS_') === 0 || localName.indexOf('Mars_') === 0 || localName.indexOf('Travis_') === 0  || localName.indexOf('Maclan_')=== 0 || localName.indexOf('Mambo_')=== 0);
   var manufacturerMatch = manufacturer
     && (['4300cf1900090100', '4300cf1909090100', '4300cf1907090100'].indexOf(manufacturer) >= 0);
 


### PR DESCRIPTION
Include support for Mambo by adding `|| localName.indexOf('Mambo_')=== 0` into `isDronePeripheral` function.

Tested on MacBook Pro 15" Mid-2014 on Sierra 10.12.2 (16C67) with Mambo Firmware 1.0.17